### PR TITLE
Fix icons ;

### DIFF
--- a/MainApplication/CMakeLists.txt
+++ b/MainApplication/CMakeLists.txt
@@ -71,7 +71,7 @@ add_executable(
     ${app_headers}
     ${app_inlines}
     ${app_uis_moc}
-    ${resources}
+    ${app_resources}
     )
 
 target_link_libraries (${PROJECT_NAME} PUBLIC


### PR DESCRIPTION
There was a typo regarding resources handling in the CMakeLists, preventing resources (e.g. icons) to be used in the main-app.