### PR TITLE
Add missing include ;

### DIFF
--- a/ShaderEditor/ShaderEditorWidget.hpp
+++ b/ShaderEditor/ShaderEditorWidget.hpp
@@ -2,6 +2,8 @@
 
 #include <QWidget>
 
+#include <memory>
+
 namespace Ui {
 class ShaderEditorWidget;
 }


### PR DESCRIPTION
When compiling the current master with the current master of Radium-Engine, I went accross a missing include:
in file `ShaderEditor/ShaderEditorWidget.hpp` , `memory` is needed since we use `shared_ptr`.
