### PR TITLE
Fix typo in MainWindow UI

### DIFF
--- a/Sandbox/Gui/ui/MainWindow.ui
+++ b/Sandbox/Gui/ui/MainWindow.ui
@@ -766,7 +766,7 @@
     <string>Snapshot</string>
    </property>
    <property name="toolTip">
-    <string>Takes a shnapshot of the current view</string>
+    <string>Takes a snapshot of the current view</string>
    </property>
   </action>
   <action name="actionTrackball">


### PR DESCRIPTION
Fix Snapshot tool tip typo in Sandbox MainWindow.ui :

Before:
![Screenshot from 2021-04-10 16-31-39](https://user-images.githubusercontent.com/47781464/114273558-cc290680-9a1a-11eb-8d96-bfe58757f9a2.png)

After:
![Screenshot from 2021-04-10 16-37-59](https://user-images.githubusercontent.com/47781464/114273665-45c0f480-9a1b-11eb-8c07-c26ac89e4cf2.png)


