### PR TITLE
[gui] Add "About dialog" with access to settings editor.

### DIFF
--- a/Sandbox/CMakeLists.txt
+++ b/Sandbox/CMakeLists.txt
@@ -30,6 +30,7 @@ set(CMAKE_AUTORCC ON)
 set(app_sources
         main.cpp
         MainApplication.cpp
+        Gui/AboutDialog.cpp
         Gui/ColorWidget.cpp
         Gui/MainWindow.cpp
         Gui/MaterialEditor.cpp
@@ -38,6 +39,7 @@ set(app_sources
 
 set(app_headers
         MainApplication.hpp
+        Gui/AboutDialog.hpp
         Gui/ColorWidget.hpp
         Gui/MainWindow.hpp
         Gui/MaterialEditor.hpp
@@ -47,6 +49,7 @@ set(app_headers
    )
 
 set(app_uis
+        Gui/ui/AboutDialog.ui
         Gui/ui/MainWindow.ui
         Gui/ui/MaterialEditor.ui
         Gui/ui/RotationEditor.ui

--- a/Sandbox/Gui/AboutDialog.cpp
+++ b/Sandbox/Gui/AboutDialog.cpp
@@ -1,0 +1,21 @@
+#include "ui_AboutDialog.h"
+#include <Gui/AboutDialog.hpp>
+#include <QPushButton>
+
+namespace Ra {
+namespace Gui {
+AboutDialog::AboutDialog( QWidget* parent ) : QDialog( parent ), ui( new Ui::AboutDialog ) {
+    ui->setupUi( this );
+    ui->aboutbuttons->button( QDialogButtonBox::RestoreDefaults )->setText( "Settings" );
+    connect( ui->aboutbuttons->button( QDialogButtonBox::RestoreDefaults ),
+             &QPushButton::pressed,
+             this,
+             &AboutDialog::settings );
+}
+
+AboutDialog::~AboutDialog() {
+    delete ui;
+}
+
+} // namespace Gui
+} // namespace Ra

--- a/Sandbox/Gui/AboutDialog.hpp
+++ b/Sandbox/Gui/AboutDialog.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <Gui/RaGui.hpp>
+#include <QDialog>
+
+QT_BEGIN_NAMESPACE
+namespace Ui {
+class AboutDialog;
+}
+QT_END_NAMESPACE
+
+namespace Ra {
+namespace Gui {
+
+class AboutDialog : public QDialog
+{
+    Q_OBJECT
+
+  public:
+    explicit AboutDialog( QWidget* parent = nullptr );
+    ~AboutDialog() override;
+
+  signals:
+    /// Emitted when the settings button is pressed
+    void settings();
+
+    /// Emitted when the settings help is pressed
+    void help();
+
+  private:
+    Ui::AboutDialog* ui;
+};
+
+} // namespace Gui
+} // namespace Ra

--- a/Sandbox/Gui/MainWindow.cpp
+++ b/Sandbox/Gui/MainWindow.cpp
@@ -47,6 +47,8 @@ MainWindow::MainWindow( QWidget* parent ) : MainWindowInterface( parent ) {
     // not initialized. Listen to the "started" signal.
 
     setupUi( this );
+    m_about = new AboutDialog( this );
+    connect( m_about, &AboutDialog::settings, this, &MainWindow::editSettings );
 
     m_viewer = new Viewer();
     // Registers the application dependant camera manipulators
@@ -662,6 +664,10 @@ void MainWindow::on_actionStep_triggered() {
     mainApp->askForUpdate();
 }
 
+void MainWindow::on_actionAbout_triggered() {
+    m_about->show();
+}
+
 void MainWindow::timelinePlay( bool play ) {
     actionPlay->setChecked( play );
     if ( !m_lockTimeSystem )
@@ -854,6 +860,11 @@ void MainWindow::addPluginPath() {
 
 void MainWindow::clearPluginPaths() {
     mainApp->clearPluginDirectories();
+}
+
+void MainWindow::editSettings() {
+    LOG( logINFO ) << "Edit settings .";
+    mainApp->editSettings();
 }
 
 } // namespace Gui

--- a/Sandbox/Gui/MainWindow.hpp
+++ b/Sandbox/Gui/MainWindow.hpp
@@ -1,6 +1,7 @@
 #ifndef RADIUMENGINE_MAINWINDOW_HPP
 #define RADIUMENGINE_MAINWINDOW_HPP
 
+#include <Gui/AboutDialog.hpp>
 #include <Gui/MainWindowInterface.hpp>
 #include <Gui/MaterialEditor.hpp>
 #include <Gui/RaGui.hpp>
@@ -177,8 +178,12 @@ class MainWindow : public Ra::Gui::MainWindowInterface, private Ui::MainWindow
     /// Allow to manage registered plugin paths
     /// @todo : for now, only add a new path ... make full management available
     void addPluginPath();
+
     /// Remove all registered plugin directories
     void clearPluginPaths();
+
+    /// Remove all registered plugin directories
+    void editSettings();
 
   private slots:
     /// \name Time events
@@ -192,6 +197,9 @@ class MainWindow : public Ra::Gui::MainWindowInterface, private Ui::MainWindow
 
     /// Slot for the user requesting to reset time.
     void on_actionStop_triggered();
+
+    /// Slot for the user requesting about.
+    void on_actionAbout_triggered();
 
     /// Slot for the user requesting to play/pause time through the timeline.
     void timelinePlay( bool play );
@@ -230,6 +238,9 @@ class MainWindow : public Ra::Gui::MainWindowInterface, private Ui::MainWindow
 
     /// Guard TimeSystem against issue with Timeline signals.
     bool m_lockTimeSystem {false};
+
+    // About dialog
+    AboutDialog* m_about;
 };
 
 } // namespace Gui

--- a/Sandbox/Gui/ui/AboutDialog.ui
+++ b/Sandbox/Gui/ui/AboutDialog.ui
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AboutDialog</class>
+ <widget class="QDialog" name="AboutDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>489</width>
+    <height>280</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTextBrowser" name="radiumText">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="locale">
+      <locale language="English" country="UnitedStates"/>
+     </property>
+     <property name="inputMethodHints">
+      <set>Qt::ImhNone</set>
+     </property>
+     <property name="html">
+      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.SF NS Text'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Radium Sandbox application&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Storm-IRIT, CNRS-Université de Toulouse&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Radium Engine : &lt;a href=&quot;https://github.com/STORM-IRIT/Radium-Engine&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#419cff;&quot;&gt;https://github.com/STORM-IRIT/Radium-Engine&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;img src=&quot;:/Resources/Icons/RadiumIcon.png&quot; /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="aboutbuttons">
+     <property name="accessibleDescription">
+      <string/>
+     </property>
+     <property name="locale">
+      <locale language="English" country="UnitedStates"/>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Help|QDialogButtonBox::RestoreDefaults</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../Resources/ApplicationIcons.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>aboutbuttons</sender>
+   <signal>rejected()</signal>
+   <receiver>AboutDialog</receiver>
+   <slot>close()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>244</x>
+     <y>259</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>244</x>
+     <y>139</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Sandbox/Gui/ui/MainWindow.ui
+++ b/Sandbox/Gui/ui/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1350</width>
-    <height>972</height>
+    <height>975</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -27,7 +27,7 @@
      <x>0</x>
      <y>0</y>
      <width>1350</width>
-     <height>24</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFILE">


### PR DESCRIPTION
Demonstrate the use of setting editor proposed in Radium PR #531 

Questions : 
  - Do we move the `AboutDialog` to the gui library into Radium-Engine so that any application can use it easily ?