### PR TITLE
[Sandbox] Improved management of ShaderBox 

### DIFF
--- a/Sandbox/Gui/MainWindow.cpp
+++ b/Sandbox/Gui/MainWindow.cpp
@@ -508,7 +508,7 @@ void MainWindow::updateDisplayedTexture() {
 }
 
 void MainWindow::updateBackgroundColor( QColor c ) {
-    // FIXME : sometime, settings does not define colrs but Qt found one ....
+    // FIXME : sometime, settings does not define colors but Qt found one ....
     QSettings settings;
     // Get or set color from/to settings
     if ( !c.isValid() )

--- a/Sandbox/Gui/MainWindow.cpp
+++ b/Sandbox/Gui/MainWindow.cpp
@@ -416,15 +416,9 @@ void MainWindow::onSelectionChanged( const QItemSelection& /*selected*/,
             CORE_ASSERT( m_currentShaderBox->findText( shaderName.c_str() ) != -1,
                          "RO shaders must be already added to the list" );
             m_currentShaderBox->setCurrentText( shaderName.c_str() );
-            m_currentShaderBox->setEnabled(
-                true ); // just to allow exploration, as there is no simple way
-            // to change the material type
         }
         else
-        {
-            m_currentShaderBox->setEnabled( false );
-            m_currentShaderBox->setCurrentText( "" );
-        }
+        { m_currentShaderBox->setCurrentText( "" ); }
         m_skelAnim->selectionChanged( ent );
         m_timeline->selectionChanged( ent );
     }


### PR DESCRIPTION
In the Sandbox application, populate the shader box (add/remove shader names) from the Radium signal manager instead of on scene loading.
This allow to dynamically add selectable render-objects (that make the application to crash before this PR) and reopen some edition capabilities on Radium (not in this PR).
