### PR TITLE
Adaptation to signal manager uses of Core::Utils::Observable

### DIFF
--- a/Sandbox/Gui/MainWindow.hpp
+++ b/Sandbox/Gui/MainWindow.hpp
@@ -230,6 +230,16 @@ class MainWindow : public Ra::Gui::MainWindowInterface, private Ui::MainWindow
 
     /// Guard TimeSystem against issue with Timeline signals.
     bool m_lockTimeSystem {false};
+
+    /// Observers id for engine event
+    ///@{
+    int m_entityAddObserverId {-1};
+    int m_entityRemoveObserverId {-1};
+    int m_componentAddObserverId {-1};
+    int m_componentRemoveObserverId {-1};
+    int m_roAddObserverId {-1};
+    int m_roRemoveObserverId {-1};
+    ///@}
 };
 
 } // namespace Gui


### PR DESCRIPTION
see PR #763 on Radium-Engine.
This PR should be merged right after #763 is merged.